### PR TITLE
https heroku issues fix for backend calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -386,4 +386,5 @@ if __name__ == "__main__":
     app.run(
         host=os.getenv("IP", "0.0.0.0"),
         port=int(os.getenv("PORT", "8081")),
+        ssl_context='adhoc',
     )


### PR DESCRIPTION
When making calls to backend they are being sent as http when the website is being served over https. I think this is what was giving me a 500 error.
Small change hoping it works.